### PR TITLE
UI improvements - first version

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -138,7 +138,7 @@
 
     <div class="app-grid-column" aria-live="polite">
 
-      <h2 class="govuk-heading-s">Text contrast with object background</h2>
+      <h2 class="govuk-heading-s">Text contrast with object colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-text-contrast-with-object-contrast-ratio>
           {{- textContrastWithObject.contrastRatio -}}
@@ -150,16 +150,33 @@
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-object-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title >   @@{{ textContrastWithObject.status.title }}@@
-              <p class="govuk-heading-l govuk-!-margin-bottom-0" data-app-text-contrast-with-object-status-title
-      style="color: var(--app-text-contrast-with-object-color);">
-        ##{{ textContrastWithObject.status.title }}##
-              </p>
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
+        {{ textContrastWithObject.status.title }}
             </span>
           </li>
-          <li>WCAG AAA: <span style="color: var(--app-text-contrast-with-object-color);
+
+          <li>WCAG AAA: 
+            <span style="color: var(--app-text-contrast-with-object-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
-              {{ textContrastWithObject.status }}
+              {{ textContrastWithObject.status.title }}
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="govuk-body govuk-!-margin-top-3">
+        <span class="govuk-!-font-weight-bold">Large text: </span>
+        <ul class="govuk-list govuk-!-margin-top-0">
+          <li>WCAG AA: 
+            <span style="color: var(--app-text-contrast-with-object-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
+          {{ textContrastWithObject.status.title }}
+            </span>
+          </li>
+          <li>WCAG AAA: 
+            <span style="color: var(--app-text-contrast-with-object-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
+              {{ textContrastWithObject.status.title }}
             </span>
           </li>
         </ul>
@@ -169,41 +186,86 @@
         <li>
           <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum">
           1.4.3: Contrast (Minimum)
-        </a>
+          </a>
         </li>
         <li>
           <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced">
           1.4.6: Contrast (Enhanced)
-        </a>
+          </a>
         </li>
       </ul>
 
-      <h2 class="govuk-heading-s">Object contrast with page background</h2>
-      <p class="govuk-heading-l govuk-!-margin-bottom-0" data-app-object-contrast-with-page-status-title
-            style="color: var(--app-object-contrast-with-page-color);">
-        {{ objectContrastWithPage.status.title }}
-      </p>
+      <h2 class="govuk-heading-s">Object contrast with page (background) colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-object-contrast-with-page-contrast-ratio>
           {{- objectContrastWithPage.contrastRatio -}}
         </span>:1
       </p>
-      <p>
+
+      <div class="govuk-body govuk-!-margin-top-3">
+        <span class="govuk-!-font-weight-bold">Graphical Objects: </span>
+        <ul class="govuk-list govuk-!-margin-top-0">
+          <li>WCAG AA: 
+            <span style="color: var(--app-object-contrast-with-page-color);
+          text-transform: uppercase; font-weight: 700" data-app-object-contrast-with-page-status-title >
+          {{ objectContrastWithPage.status.title }}
+              </p>
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <p class="govuk-!-margin-bottom-7">
         <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#non-text-contrast">
           1.4.11: Non-text Contrast
         </a>
       </p>
 
-      <h2 class="govuk-heading-s">Text contrast with alpha background</h2>
-      <p class="govuk-heading-l govuk-!-margin-bottom-0" data-app-text-contrast-with-alpha-background-title
-            style="color: var(--app-text-contrast-with-alpha-background-color);">
-        {{ textContrastWithAlphaBackground.status.title }}
-      </p>
+      <h2 class="govuk-heading-s">Text contrast with alpha composed background colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-text-contrast-with-alpha-background-contrast-ratio>
           {{- textContrastWithAlphaBackground.contrastRatio -}}
         </span>:1
       </p>
+      
+      <div class="govuk-body govuk-!-margin-top-3">
+        <span class="govuk-!-font-weight-bold">Normal text: </span>
+        <ul class="govuk-list govuk-!-margin-top-0">
+          <li>WCAG AA: 
+            <span style="color: var(--app-text-contrast-with-alpha-background-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
+              {{ textContrastWithAlphaBackground.status.title }}
+            </span>
+          </li>
+
+          <li>WCAG AAA: 
+            <span style="color: var(--app-text-contrast-with-alpha-background-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
+              {{ textContrastWithAlphaBackground.status.title }}
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="govuk-body govuk-!-margin-top-3">
+        <span class="govuk-!-font-weight-bold">Large text: </span>
+        <ul class="govuk-list govuk-!-margin-top-0">
+          <li>WCAG AA: 
+            <span style="color: var(--app-text-contrast-with-alpha-background-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
+          {{ textContrastWithAlphaBackground.status.title }}
+            </span>
+          </li>
+
+          <li>WCAG AAA: 
+            <span style="color: var(--app-text-contrast-with-alpha-background-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
+              {{ textContrastWithAlphaBackground.status.title }}
+            </span>
+          </li>
+        </ul>
+      </div>
+
       <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
         <li>
           <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum">

--- a/index.njk
+++ b/index.njk
@@ -1,22 +1,6 @@
 {% extends "layouts/main.njk" %}
 
 {% block content %}
-  <style>
-    /* initial colours */
-    :root {
-      --app-input-page-background: {{input.pageBackground}};
-      --app-input-object-background: {{input.objectBackground}};
-      --app-input-object-alpha-background: {{input.appliedAlpha}};
-      --app-input-alpha-channel: {{input.alphaChannel}};
-      --app-input-applied-alpha: {{input.appliedAlpha}};
-      --app-input-text-color: {{input.textColour}};
-      --app-object-contrast-with-page-color: {{objectContrastWithPage.status.color}};
-      --app-text-contrast-with-object-color: {{textContrastWithObject.status.color}};
-      --app-text-contrast-with-page-color: {{textContrastWithPage.status.color}};
-      --app-text-contrast-with-alpha-background-color: {{textContrastWithAlphaBackground.status.color}};
-
-    }
-  </style>
   <h1 class="govuk-heading-xl">Contrast Checker With Alpha Support</h1>
   <div class="app-grid">
     <div class="app-grid-column">
@@ -138,7 +122,7 @@
 
     <div class="app-grid-column" aria-live="polite">
 
-      <h2 class="govuk-heading-s">Text contrast with object colour</h2>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Text contrast with object colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-text-contrast-with-object-contrast-ratio>
           {{- textContrastWithObject.contrastRatio -}}
@@ -149,16 +133,16 @@
         <span class="govuk-!-font-weight-bold">Normal text: </span>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
-            <span style="color: var(--app-text-contrast-with-object-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
-        {{ textContrastWithObject.status.title }}
+            <span style="color: var(--app-text-contrast-with-object-normal-aa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-normal-aa>
+        {{ textContrastWithObject.normalAA.title }}
             </span>
           </li>
 
           <li>WCAG AAA: 
-            <span style="color: var(--app-text-contrast-with-object-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
-              {{ textContrastWithObject.status.title }}
+            <span style="color: var(--app-text-contrast-with-object-normal-aaa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-normal-aaa>
+              {{ textContrastWithObject.normalAAA.title }}
             </span>
           </li>
         </ul>
@@ -168,21 +152,21 @@
         <span class="govuk-!-font-weight-bold">Large text: </span>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
-            <span style="color: var(--app-text-contrast-with-object-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
-          {{ textContrastWithObject.status.title }}
+            <span style="color: var(--app-text-contrast-with-object-large-aa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-large-aa>
+          {{ textContrastWithObject.largeAA.title }}
             </span>
           </li>
           <li>WCAG AAA: 
-            <span style="color: var(--app-text-contrast-with-object-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
-              {{ textContrastWithObject.status.title }}
+            <span style="color: var(--app-text-contrast-with-object-large-aaa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-large-aaa>
+              {{ textContrastWithObject.largeAAA.title }}
             </span>
           </li>
         </ul>
       </div>
 
-      <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
+      <ul class="govuk-list govuk-!-margin-bottom-5 govuk-body-s">
         <li>
           <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum" target="_blank" rel="noopener noreferrer">
           1.4.3: Contrast (Minimum)
@@ -195,7 +179,7 @@
         </li>
       </ul>
 
-      <h2 class="govuk-heading-s">Object contrast with page (background) colour</h2>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Object contrast with page (background) colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-object-contrast-with-page-contrast-ratio>
           {{- objectContrastWithPage.contrastRatio -}}
@@ -207,21 +191,20 @@
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-object-contrast-with-page-color);
-          text-transform: uppercase; font-weight: 700" data-app-object-contrast-with-page-status-title >
-          {{ objectContrastWithPage.status.title }}
-              </p>
+          text-transform: uppercase; font-weight: 700" data-app-object-contrast-with-page-object-aa >
+          {{ objectContrastWithPage.objectAA.title }}
             </span>
           </li>
         </ul>
       </div>
 
-      <p class="govuk-!-margin-bottom-7">
+      <p class="govuk-!-margin-bottom-9 govuk-body-s">
         <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#non-text-contrast" target="_blank" rel="noopener noreferrer">
           1.4.11: Non-text Contrast
         </a>
       </p>
 
-      <h2 class="govuk-heading-s">Text contrast with alpha composed background colour</h2>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Text contrast with alpha composed background colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-text-contrast-with-alpha-background-contrast-ratio>
           {{- textContrastWithAlphaBackground.contrastRatio -}}
@@ -232,16 +215,16 @@
         <span class="govuk-!-font-weight-bold">Normal text: </span>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
-            <span style="color: var(--app-text-contrast-with-alpha-background-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
-              {{ textContrastWithAlphaBackground.status.title }}
+            <span style="color: var(--app-text-contrast-with-alpha-background-normal-aa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-normal-aa>
+              {{ textContrastWithAlphaBackground.normalAA.title }}
             </span>
           </li>
 
           <li>WCAG AAA: 
-            <span style="color: var(--app-text-contrast-with-alpha-background-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
-              {{ textContrastWithAlphaBackground.status.title }}
+            <span style="color: var(--app-text-contrast-with-alpha-background-normal-aaa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-normal-aaa>
+              {{ textContrastWithAlphaBackground.normalAAA.title }}
             </span>
           </li>
         </ul>
@@ -251,22 +234,22 @@
         <span class="govuk-!-font-weight-bold">Large text: </span>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
-            <span style="color: var(--app-text-contrast-with-alpha-background-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
-          {{ textContrastWithAlphaBackground.status.title }}
+            <span style="color: var(--app-text-contrast-with-alpha-background-large-aa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-large-aa>
+          {{ textContrastWithAlphaBackground.largeAA.title }}
             </span>
           </li>
 
           <li>WCAG AAA: 
-            <span style="color: var(--app-text-contrast-with-alpha-background-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-title>
-              {{ textContrastWithAlphaBackground.status.title }}
+            <span style="color: var(--app-text-contrast-with-alpha-background-large-aaa-color);
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-large-aaa>
+              {{ textContrastWithAlphaBackground.largeAAA.title }}
             </span>
           </li>
         </ul>
       </div>
 
-      <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
+      <ul class="govuk-list govuk-!-margin-bottom-9 govuk-body-s">
         <li>
           <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum" target="_blank" rel="noopener noreferrer">
           1.4.3: Contrast (Minimum)

--- a/index.njk
+++ b/index.njk
@@ -4,22 +4,22 @@
   <style>
     /* initial colours */
     :root {
-      --app-input-page-background: {{ input.pageBackground }};
-      --app-input-object-background: {{ input.objectBackground }};
-      --app-input-object-alpha-background: {{ input.appliedAlpha }};
-      --app-input-alpha-channel: {{ input.alphaChannel }};
-      --app-input-applied-alpha: {{ input.appliedAlpha }};
-      --app-input-text-color: {{ input.textColour }};
-      --app-object-contrast-with-page-color: {{ objectContrastWithPage.status.color }}; 
-      --app-text-contrast-with-object-color: {{ textContrastWithObject.status.color }};
-      --app-text-contrast-with-page-color: {{ textContrastWithPage.status.color }}; 
-      --app-text-contrast-with-alpha-background-color: {{ textContrastWithAlphaBackground.status.color }}; 
+      --app-input-page-background: {{input.pageBackground}};
+      --app-input-object-background: {{input.objectBackground}};
+      --app-input-object-alpha-background: {{input.appliedAlpha}};
+      --app-input-alpha-channel: {{input.alphaChannel}};
+      --app-input-applied-alpha: {{input.appliedAlpha}};
+      --app-input-text-color: {{input.textColour}};
+      --app-object-contrast-with-page-color: {{objectContrastWithPage.status.color}};
+      --app-text-contrast-with-object-color: {{textContrastWithObject.status.color}};
+      --app-text-contrast-with-page-color: {{textContrastWithPage.status.color}};
+      --app-text-contrast-with-alpha-background-color: {{textContrastWithAlphaBackground.status.color}};
 
     }
   </style>
   <h1 class="govuk-heading-xl">Contrast Checker With Alpha Support</h1>
   <div class="app-grid">
-    <div class="app-grid-column">      
+    <div class="app-grid-column">
       <form>
         {{ govukInput({
           formGroup: {
@@ -55,7 +55,6 @@
             spellcheck: "off"
           }
         }) }}
-
 
         {{ govukInput({
           classes: "govuk-input--width-2",
@@ -120,7 +119,7 @@
         }) }}
       </form>
     </div>
-  
+
     <div class="app-grid-column">
       <h2 class="govuk-heading-s">Text + Object + Page Colours:</h2>
       <div class="app-input-page">
@@ -128,7 +127,7 @@
           Text
         </div>
       </div>
-  
+
       <h2 class="govuk-heading-s">Text + Alpha Composed Colours:</h2>
       <div class="app-input-page">
         <div class="app-input-object-alpha">
@@ -146,24 +145,38 @@
         </span>:1
       </p>
 
-      <div class="govuk-body govuk-!-margin-top-3"> 
+      <div class="govuk-body govuk-!-margin-top-3">
         <span class="govuk-!-font-weight-bold">Normal text: </span>
-        <ul class="govuk-list govuk-!-margin-top-0"> 
-          <li>WCAG AA: <span style="color: var(--app-text-contrast-with-object-color);
+        <ul class="govuk-list govuk-!-margin-top-0">
+          <li>WCAG AA: 
+            <span style="color: var(--app-text-contrast-with-object-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title >   @@{{ textContrastWithObject.status.title }}@@
-      </p>
-      <p class="govuk-heading-l govuk-!-margin-bottom-0" data-app-text-contrast-with-object-status-title
+              <p class="govuk-heading-l govuk-!-margin-bottom-0" data-app-text-contrast-with-object-status-title
       style="color: var(--app-text-contrast-with-object-color);">
-        ##{{ textContrastWithObject.status.title }}## </span></li>
+        ##{{ textContrastWithObject.status.title }}##
+              </p>
+            </span>
+          </li>
           <li>WCAG AAA: <span style="color: var(--app-text-contrast-with-object-color);
-          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title> {{ textContrastWithObject.status }} </span></li>
+          text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-status-title>
+              {{ textContrastWithObject.status }}
+            </span>
+          </li>
         </ul>
       </div>
-      <p class="govuk-!-margin-bottom-7">
-        <a class="govuk-link" href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum">
-          Understanding Success Criterion 1.4.3: Contrast (Minimum)
+
+      <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
+        <li>
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum">
+          1.4.3: Contrast (Minimum)
         </a>
-      </p>
+        </li>
+        <li>
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced">
+          1.4.6: Contrast (Enhanced)
+        </a>
+        </li>
+      </ul>
 
       <h2 class="govuk-heading-s">Object contrast with page background</h2>
       <p class="govuk-heading-l govuk-!-margin-bottom-0" data-app-object-contrast-with-page-status-title
@@ -176,8 +189,8 @@
         </span>:1
       </p>
       <p>
-        <a class="govuk-link" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast">
-          Understanding Success Criterion 1.4.11: Non-text Contrast
+        <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#non-text-contrast">
+          1.4.11: Non-text Contrast
         </a>
       </p>
 
@@ -191,13 +204,20 @@
           {{- textContrastWithAlphaBackground.contrastRatio -}}
         </span>:1
       </p>
-      <p class="govuk-!-margin-bottom-7">
-        <a class="govuk-link" href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum">
-          Understanding Success Criterion 1.4.3: Contrast (Minimum)
-        </a>
-      </p>
+      <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
+        <li>
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum">
+          1.4.3: Contrast (Minimum)
+          </a>
+        </li>
+        <li>
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced">
+          1.4.6: Contrast (Enhanced)
+          </a>
+        </li>
+      </ul>
 
     </div>
-    
+
   </div>
 {% endblock %}

--- a/index.njk
+++ b/index.njk
@@ -125,7 +125,6 @@
       <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Text contrast with object colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-text-contrast-with-object-contrast-ratio>
-          {{- textContrastWithObject.contrastRatio -}}
         </span>:1
       </p>
 
@@ -135,14 +134,12 @@
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-object-normal-aa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-normal-aa>
-        {{ textContrastWithObject.normalAA.title }}
             </span>
           </li>
 
           <li>WCAG AAA: 
             <span style="color: var(--app-text-contrast-with-object-normal-aaa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-normal-aaa>
-              {{ textContrastWithObject.normalAAA.title }}
             </span>
           </li>
         </ul>
@@ -154,13 +151,11 @@
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-object-large-aa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-large-aa>
-          {{ textContrastWithObject.largeAA.title }}
             </span>
           </li>
           <li>WCAG AAA: 
             <span style="color: var(--app-text-contrast-with-object-large-aaa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-object-large-aaa>
-              {{ textContrastWithObject.largeAAA.title }}
             </span>
           </li>
         </ul>
@@ -182,7 +177,6 @@
       <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Object contrast with page (background) colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-object-contrast-with-page-contrast-ratio>
-          {{- objectContrastWithPage.contrastRatio -}}
         </span>:1
       </p>
 
@@ -192,7 +186,6 @@
           <li>WCAG AA: 
             <span style="color: var(--app-object-contrast-with-page-color);
           text-transform: uppercase; font-weight: 700" data-app-object-contrast-with-page-object-aa >
-          {{ objectContrastWithPage.objectAA.title }}
             </span>
           </li>
         </ul>
@@ -207,7 +200,6 @@
       <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Text contrast with alpha composed background colour</h2>
       <p class="govuk-heading-xl govuk-!-margin-bottom-0">
         <span data-app-text-contrast-with-alpha-background-contrast-ratio>
-          {{- textContrastWithAlphaBackground.contrastRatio -}}
         </span>:1
       </p>
       
@@ -217,14 +209,12 @@
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-alpha-background-normal-aa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-normal-aa>
-              {{ textContrastWithAlphaBackground.normalAA.title }}
             </span>
           </li>
 
           <li>WCAG AAA: 
             <span style="color: var(--app-text-contrast-with-alpha-background-normal-aaa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-normal-aaa>
-              {{ textContrastWithAlphaBackground.normalAAA.title }}
             </span>
           </li>
         </ul>
@@ -236,14 +226,12 @@
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-alpha-background-large-aa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-large-aa>
-          {{ textContrastWithAlphaBackground.largeAA.title }}
             </span>
           </li>
 
           <li>WCAG AAA: 
             <span style="color: var(--app-text-contrast-with-alpha-background-large-aaa-color);
           text-transform: uppercase; font-weight: 700" data-app-text-contrast-with-alpha-background-large-aaa>
-              {{ textContrastWithAlphaBackground.largeAAA.title }}
             </span>
           </li>
         </ul>

--- a/index.njk
+++ b/index.njk
@@ -130,7 +130,7 @@
       </p>
 
       <div class="govuk-body govuk-!-margin-top-3">
-        <span class="govuk-!-font-weight-bold">Normal text: </span>
+        <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">Normal text</p>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-object-normal-aa-color);
@@ -149,7 +149,7 @@
       </div>
 
       <div class="govuk-body govuk-!-margin-top-3">
-        <span class="govuk-!-font-weight-bold">Large text: </span>
+        <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">Large text</p>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-object-large-aa-color);
@@ -187,7 +187,7 @@
       </p>
 
       <div class="govuk-body govuk-!-margin-top-3">
-        <span class="govuk-!-font-weight-bold">Graphical Objects: </span>
+        <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">Graphical Objects</p>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-object-contrast-with-page-color);
@@ -212,7 +212,7 @@
       </p>
       
       <div class="govuk-body govuk-!-margin-top-3">
-        <span class="govuk-!-font-weight-bold">Normal text: </span>
+        <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">Normal text</p>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-alpha-background-normal-aa-color);
@@ -231,7 +231,7 @@
       </div>
 
       <div class="govuk-body govuk-!-margin-top-3">
-        <span class="govuk-!-font-weight-bold">Large text: </span>
+        <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">Large text</p>
         <ul class="govuk-list govuk-!-margin-top-0">
           <li>WCAG AA: 
             <span style="color: var(--app-text-contrast-with-alpha-background-large-aa-color);

--- a/index.njk
+++ b/index.njk
@@ -184,12 +184,12 @@
 
       <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
         <li>
-          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum">
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum" target="_blank" rel="noopener noreferrer">
           1.4.3: Contrast (Minimum)
           </a>
         </li>
         <li>
-          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced">
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced" target="_blank" rel="noopener noreferrer">
           1.4.6: Contrast (Enhanced)
           </a>
         </li>
@@ -216,7 +216,7 @@
       </div>
 
       <p class="govuk-!-margin-bottom-7">
-        <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#non-text-contrast">
+        <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#non-text-contrast" target="_blank" rel="noopener noreferrer">
           1.4.11: Non-text Contrast
         </a>
       </p>
@@ -268,12 +268,12 @@
 
       <ul class="govuk-list govuk-!-margin-bottom-7 govuk-body-s">
         <li>
-          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum">
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-minimum" target="_blank" rel="noopener noreferrer">
           1.4.3: Contrast (Minimum)
           </a>
         </li>
         <li>
-          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced">
+          <a class="govuk-link" href="https://www.w3.org/TR/WCAG22/#contrast-enhanced" target="_blank" rel="noopener noreferrer">
           1.4.6: Contrast (Enhanced)
           </a>
         </li>

--- a/javascript/all.js
+++ b/javascript/all.js
@@ -70,17 +70,33 @@ function renderView (data) {
   rootStyle.setProperty('--app-input-applied-alpha', data.input.appliedAlpha)
   rootStyle.setProperty('--app-input-alpha-channel', data.input.alphaChannel)
 
-  rootStyle.setProperty('--app-object-contrast-with-page-color', data.objectContrastWithPage.status.color)
-  rootStyle.setProperty('--app-text-contrast-with-object-color', data.textContrastWithObject.status.color)
-  rootStyle.setProperty('--app-text-contrast-with-alpha-background-color', data.textContrastWithAlphaBackground.status.color)
+  rootStyle.setProperty('--app-object-contrast-with-page-color', data.objectContrastWithPage.objectAA.color)
+
+  rootStyle.setProperty('--app-text-contrast-with-object-normal-aa-color', data.textContrastWithObject.normalAA.color)
+  rootStyle.setProperty('--app-text-contrast-with-object-normal-aaa-color', data.textContrastWithObject.normalAAA.color)
+  rootStyle.setProperty('--app-text-contrast-with-object-large-aa-color', data.textContrastWithObject.largeAA.color)
+  rootStyle.setProperty('--app-text-contrast-with-object-large-aaa-color', data.textContrastWithObject.largeAAA.color)
+
+  rootStyle.setProperty('--app-text-contrast-with-alpha-background-normal-aa-color', data.textContrastWithAlphaBackground.normalAA.color)
+  rootStyle.setProperty('--app-text-contrast-with-alpha-background-normal-aaa-color', data.textContrastWithAlphaBackground.normalAAA.color)
+  rootStyle.setProperty('--app-text-contrast-with-alpha-background-large-aa-color', data.textContrastWithAlphaBackground.largeAA.color)
+  rootStyle.setProperty('--app-text-contrast-with-alpha-background-large-aaa-color', data.textContrastWithAlphaBackground.largeAAA.color)
   
   document.querySelector('[data-app-text-contrast-with-object-contrast-ratio]').textContent = data.textContrastWithObject.contrastRatio
   document.querySelector('[data-app-object-contrast-with-page-contrast-ratio]').textContent = data.objectContrastWithPage.contrastRatio
   document.querySelector('[data-app-text-contrast-with-alpha-background-contrast-ratio]').textContent = data.textContrastWithAlphaBackground.contrastRatio
   
-  document.querySelectorAll('[data-app-text-contrast-with-object-status-title]').forEach(item => item.textContent = data.textContrastWithObject.status.title)
-  document.querySelector('[data-app-object-contrast-with-page-status-title]').textContent = data.objectContrastWithPage.status.title 
-  document.querySelectorAll('[data-app-text-contrast-with-alpha-background-title]').forEach(item => item.textContent = data.textContrastWithAlphaBackground.status.title)
+  document.querySelector('[data-app-text-contrast-with-object-normal-aa]').textContent = data.textContrastWithObject.normalAA.title
+  document.querySelector('[data-app-text-contrast-with-object-normal-aaa]').textContent = data.textContrastWithObject.normalAAA.title
+  document.querySelector('[data-app-text-contrast-with-object-large-aa]').textContent = data.textContrastWithObject.largeAA.title
+  document.querySelector('[data-app-text-contrast-with-object-large-aaa]').textContent = data.textContrastWithObject.largeAAA.title
+
+  document.querySelector('[data-app-object-contrast-with-page-object-aa]').textContent = data.objectContrastWithPage.objectAA.title
+
+  document.querySelector('[data-app-text-contrast-with-alpha-background-normal-aa]').textContent = data.textContrastWithAlphaBackground.normalAA.title
+  document.querySelector('[data-app-text-contrast-with-alpha-background-normal-aaa]').textContent = data.textContrastWithAlphaBackground.normalAAA.title
+  document.querySelector('[data-app-text-contrast-with-alpha-background-large-aa]').textContent = data.textContrastWithAlphaBackground.largeAA.title
+  document.querySelector('[data-app-text-contrast-with-alpha-background-large-aaa]').textContent = data.textContrastWithAlphaBackground.largeAAA.title
   
   document.getElementById('appliedAlpha-colour').value = data.input.appliedAlpha
   document.getElementById('appliedAlpha').value = data.input.appliedAlpha

--- a/javascript/all.js
+++ b/javascript/all.js
@@ -78,9 +78,9 @@ function renderView (data) {
   document.querySelector('[data-app-object-contrast-with-page-contrast-ratio]').textContent = data.objectContrastWithPage.contrastRatio
   document.querySelector('[data-app-text-contrast-with-alpha-background-contrast-ratio]').textContent = data.textContrastWithAlphaBackground.contrastRatio
   
-  document.querySelectorAll('[data-app-text-contrast-with-object-status-title]').forEach(item => item.textContent = data.textContrastWithObject.status.title )
+  document.querySelectorAll('[data-app-text-contrast-with-object-status-title]').forEach(item => item.textContent = data.textContrastWithObject.status.title)
   document.querySelector('[data-app-object-contrast-with-page-status-title]').textContent = data.objectContrastWithPage.status.title 
-  document.querySelector('[data-app-text-contrast-with-alpha-background-title]').textContent = data.textContrastWithAlphaBackground.status.title 
+  document.querySelectorAll('[data-app-text-contrast-with-alpha-background-title]').forEach(item => item.textContent = data.textContrastWithAlphaBackground.status.title)
   
   document.getElementById('appliedAlpha-colour').value = data.input.appliedAlpha
   document.getElementById('appliedAlpha').value = data.input.appliedAlpha

--- a/javascript/contrast.js
+++ b/javascript/contrast.js
@@ -11,36 +11,16 @@ var DEFAULT_INPUT = {
 }
 
 // https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/contrast-ratio.js
-var textLevels = {
-  "Fail": {
-    range: [0, 3],
+var levels = {
+  "fail": {
+    title: "Fail",
     color: "hsl(0, 100%, 40%)"
   },
-  "AA Large": {
-    range: [3, 4.5],
-    color: "hsl(22, 84%, 37%)"
-  },
-  "AA": {
-    range: [4.5, 7],
+  "pass": {
+    title: "Pass",
     color: "hsl(142, 100%, 26%)"
-  },
-  "AAA": {
-    range: [7, 22],
-    color: "hsl(142, 52%, 24%)"
   }
 };
-
-// https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast
-var nonTextLevels = {
-  "Fail": {
-    range: [0, 3],
-    color: "hsl(0, 100%, 40%)"
-  },
-  "AA": {
-    range: [3, 22],
-    color: "hsl(142, 100%, 26%)"
-  }
-}
 
 function roundNumber (number) {
   // Truncate the number without rounding up
@@ -52,23 +32,29 @@ function roundNumber (number) {
   return number
 }
 
-function rangeIntersect(min, max, value) {
-  return value <= max && value >= min
-}
-
-function getLevelStatus (contrastRatio, levels) {
+// https://www.w3.org/TR/WCAG22/#contrast-minimum
+// https://www.w3.org/TR/WCAG22/#contrast-enhanced
+// https://www.w3.org/TR/WCAG22/#non-text-contrast
+function getPassFail(contrastRatio, criteria) {
   let status
-  for (var level in levels) {
-    var bounds = levels[level].range
-    var lower = bounds[0]
-    var upper = bounds[1]
-
-    if (rangeIntersect(lower, upper, contrastRatio)) {
-      status = {
-        title: level,
-        ...levels[level]
-      }
-    }
+  switch (criteria) {
+    case "NormalAA":
+      status = (contrastRatio >= 4.5) ? levels.pass : levels.fail;
+      break;
+    case "NormalAAA":
+      status = (contrastRatio >= 7) ? levels.pass : levels.fail;
+      break;
+    case "LargeAA":
+      status = (contrastRatio >= 3) ? levels.pass : levels.fail;
+      break;
+    case "LargeAAA":
+      status = (contrastRatio >= 4.5) ? levels.pass : levels.fail;
+      break;
+    case "ObjectAA":
+      status = (contrastRatio >= 3) ? levels.pass : levels.fail;
+      break;
+    default:
+      status = levels.fail;
   }
   return status
 }
@@ -134,7 +120,10 @@ function contrast (input) {
 
   let textContrastWithAlphaBackground = {
     contrastRatio: roundNumber(textContrastWithAlphaBackgroundContrastRatio),
-    status: getLevelStatus(textContrastWithAlphaBackgroundContrastRatio, textLevels)
+    normalAA: getPassFail(textContrastWithAlphaBackgroundContrastRatio, "NormalAA"),
+    normalAAA: getPassFail(textContrastWithAlphaBackgroundContrastRatio, "NormalAAA"),
+    largeAA: getPassFail(textContrastWithAlphaBackgroundContrastRatio, "LargeAA"),
+    largeAAA: getPassFail(textContrastWithAlphaBackgroundContrastRatio, "LargeAAA")
   }
   
   let textContrastWithObjectContrastRatio = hexContrastCheck(
@@ -144,7 +133,10 @@ function contrast (input) {
 
   let textContrastWithObject = {
     contrastRatio: roundNumber(textContrastWithObjectContrastRatio),
-    status: getLevelStatus(textContrastWithObjectContrastRatio, textLevels)
+    normalAA: getPassFail(textContrastWithObjectContrastRatio, "NormalAA"),
+    normalAAA: getPassFail(textContrastWithObjectContrastRatio, "NormalAAA"),
+    largeAA: getPassFail(textContrastWithObjectContrastRatio, "LargeAA"),
+    largeAAA: getPassFail(textContrastWithObjectContrastRatio, "LargeAAA")
   }
   
   let objectContrastWithPageContrastRatio = hexContrastCheck(
@@ -154,9 +146,8 @@ function contrast (input) {
 
   let objectContrastWithPage = {
     contrastRatio: roundNumber(objectContrastWithPageContrastRatio),
-    status: getLevelStatus(objectContrastWithPageContrastRatio, nonTextLevels)
+    objectAA: getPassFail(objectContrastWithPageContrastRatio, "ObjectAA")
   }
-
 
   return {
     input,

--- a/styles/all.scss
+++ b/styles/all.scss
@@ -2,7 +2,7 @@
 
 .app-grid {
   display: grid;
-  grid-gap: 2rem;
+  grid-gap: 4rem;
 }
 
 @media (min-width: 50em) {
@@ -73,4 +73,8 @@
 .govuk-hint {
   font-size: 0.75rem;
   line-height: 1rem;
+}
+
+.govuk-width-container {
+  max-width: 1020px;
 }


### PR DESCRIPTION
I aligned the layout in relation to the issue paoloantinori/contrast-checker#1, and modified the texts that were not yet consistent with the first version of the UI.

To get the pass/fail, I modified the js function on contrast.js so that it returns one of the values based on the criteria choosen and the contrast ratio.

I mention that, already in the starting project, there was a redundancy in the use of variables between index.njk and all.js. The input color values and the values resulting from the calculations in contrast.js are passed with the properties defined in all.js (e.g. rootStyle.setProperty('--app-input-page-background', data.input.pageBackground)). The variables used in index.njk between the double curly braces (e.g. {{- textContrastWithObject.contrastRatio -}}) are empty, probably due to some error in the render function, and are not needed because the value is already applied to the tag by the property.